### PR TITLE
Drop Go 1.23-1.24 and PostgreSQL 14-15 support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: arp242

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: ['14', '15', '16', '17', '18']
-        go: ['1.23', '1.26']
+        pg: ['16', '17', '18']
+        go: ['1.25', '1.26']
     steps:
     - uses: 'actions/checkout@v6'
     - uses: 'actions/setup-go@v6'

--- a/compose.yaml
+++ b/compose.yaml
@@ -63,27 +63,3 @@ services:
       'POSTGRES_DATABASE': 'pqgo'
       'POSTGRES_USER':     'pqgo'
       'POSTGRES_PASSWORD': 'unused'
-  pg15:
-    profiles:    ['pg15']
-    image:       'postgres:15'
-    ports:       ['127.0.0.1:5432:5432']
-    entrypoint:  '/init/entry.sh'
-    volumes:     ['./testdata/postgres:/init', './testdata/ssl:/ssl']
-    shm_size:    '128mb'
-    healthcheck: {test: ['CMD-SHELL', 'pg_isready -U pqgo -d pqgo'], start_period: '30s', start_interval: '1s'}
-    environment:
-      'POSTGRES_DATABASE': 'pqgo'
-      'POSTGRES_USER':     'pqgo'
-      'POSTGRES_PASSWORD': 'unused'
-  pg14:
-    profiles:    ['pg14']
-    image:       'postgres:14'
-    ports:       ['127.0.0.1:5432:5432']
-    entrypoint:  '/init/entry.sh'
-    volumes:     ['./testdata/postgres:/init', './testdata/ssl:/ssl']
-    shm_size:    '128mb'
-    healthcheck: {test: ['CMD-SHELL', 'pg_isready -U pqgo -d pqgo'], start_period: '30s', start_interval: '1s'}
-    environment:
-      'POSTGRES_DATABASE': 'pqgo'
-      'POSTGRES_USER':     'pqgo'
-      'POSTGRES_PASSWORD': 'unused'

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/lib/pq
 
-go 1.23
+go 1.25


### PR DESCRIPTION
## Summary

- Bump minimum Go version to 1.25 (drops 1.23 and 1.24)
- Drop PostgreSQL 14 and 15 from CI matrix and docker compose
- Remove `.github/FUNDING.yml` (inherited from upstream maintainer)

## Why

Trim CI surface to currently maintained Go and PostgreSQL versions. PG 14 and 15 are still upstream-maintained but we don't need to test against them in this fork.

## Notes for reviewer

- Kept Go 1.25 (not 1.26) as the floor so the existing `//go:build go1.26` split for `errors.AsType` in `as_go126.go` / `as.go` is still meaningful.
- No driver code is version-gated on PostgreSQL 14/15, so nothing else needs to change in the Go source. The only PG-version-aware code is a comment noting `sslnegotiation=direct` needs pg17+, which is unchanged.
- Left the legacy "Go 1.2 and earlier" workarounds in `conn.go` alone — they are protocol-level behavior that has been baked in for a decade; removing them is out of scope for a version-drop change.

## Test plan

- [ ] CI matrix runs on Go 1.25 and 1.26 against PG 16/17/18
- [ ] `go build ./...` and `go vet ./...` clean locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)